### PR TITLE
Add more script entities

### DIFF
--- a/pilot/r1o/choiceTypes/hintHotspotType.json
+++ b/pilot/r1o/choiceTypes/hintHotspotType.json
@@ -1,5 +1,5 @@
 {
-    "Name": "hintChatterType",
+    "Name": "hintHotspotType",
     "Options": {
         "Balcony": "balcony",
         "Corner": "corner",

--- a/pilot/r1o/choiceTypes/hintHotspotType.json
+++ b/pilot/r1o/choiceTypes/hintHotspotType.json
@@ -1,0 +1,10 @@
+{
+    "Name": "hintChatterType",
+    "Options": {
+        "Balcony": "balcony",
+        "Corner": "corner",
+        "Door": "door",
+        "Window (First Floor)": "window",
+        "Window (Second Floor)": "window2"
+    }
+}

--- a/pilot/r1o/choiceTypes/hintType.json
+++ b/pilot/r1o/choiceTypes/hintType.json
@@ -10,6 +10,6 @@
         "Unknown - Only used by info_node_cover_right": "99",
         "Crouch Cover Medium": "100",
         "Crouch Cover Low": "101",
-        "Unknown": "102"
+        "Waste Scanner Spawn (Likely not accurate anymore)": "102"
     }
 }

--- a/pilot/r1o/choiceTypes/hintType.json
+++ b/pilot/r1o/choiceTypes/hintType.json
@@ -10,6 +10,6 @@
         "Unknown - Only used by info_node_cover_right": "99",
         "Crouch Cover Medium": "100",
         "Crouch Cover Low": "101",
-        "Waste Scanner Spawn (Likely not accurate anymore)": "102"
+        "Unknown": "102"
     }
 }

--- a/pilot/r1o/choiceTypes/hintType.json
+++ b/pilot/r1o/choiceTypes/hintType.json
@@ -1,0 +1,15 @@
+{
+    "Name": "hintType",
+    "Options": {
+        "None": "0",
+        "World - Window": "2",
+        "World - Visually Interesting": "13",
+        "World - Visually Interesting (Don't Aim At)": "14",
+        "World - Visually Interesting (Stealth)": "16",
+        "Unknown - Only used by info_node_cover_left": "98",
+        "Unknown - Only used by info_node_cover_right": "99",
+        "Crouch Cover Medium": "100",
+        "Crouch Cover Low": "101",
+        "Waste Scanner Spawn (Likely not accurate anymore)": "102"
+    }
+}

--- a/pilot/r1o/choiceTypes/marvinJobType.json
+++ b/pilot/r1o/choiceTypes/marvinJobType.json
@@ -1,0 +1,12 @@
+{
+    "Name": "marvinJobType",
+    "Options": {
+        "Fight Fire": "fightFire",
+        "Welding": "welding",
+        "Wash Window": "window",
+        "Pick Up Barrel": "barrel",
+        "Put Down Barrel": "putdown",
+        "Use Weapon Rack": "weapon_rack",
+        "Use Weapon": "weapon"
+    }
+}

--- a/pilot/r1o/choiceTypes/pilotWeaponType.json
+++ b/pilot/r1o/choiceTypes/pilotWeaponType.json
@@ -1,0 +1,22 @@
+{
+    "Name": "pilotWeaponType",
+    "Options": {
+        "RE-45 Autopistol": "mp_weapon_autopistol",
+        "Hammond P2011": "mp_weapon_semipistol",
+        "B3 Wingman": "mp_weapon_wingman",
+        "Smart Pistol MK5": "mp_weapon_smart_pistol",
+        "R-101C Carbine": "mp_weapon_rspn101",
+        "G2A4 Rifle": "mp_weapon_g2",
+        "Hemlok BF-R": "mp_weapon_hemlok",
+        "R-97 Compact SMG": "mp_weapon_r97",
+        "C.A.R. SMG": "mp_weapon_car",
+        "Spitfire LMG": "mp_weapon_lmg",
+        "EVA-8 Shotgun": "mp_weapon_shotgun",
+        "Longbow-DMR Sniper": "mp_weapon_dmr",
+        "Kraber-AP Sniper": "mp_weapon_sniper",
+        "Archer Heavy Rocket": "mp_weapon_rocket_launcher",
+        "Sidewinder": "mp_weapon_smr",
+        "Mag Launcher": "mp_weapon_mgl",
+        "Charge Rifle": "mp_weapon_defender"
+    }
+}

--- a/pilot/r1o/choiceTypes/traverseType.json
+++ b/pilot/r1o/choiceTypes/traverseType.json
@@ -1,0 +1,21 @@
+{
+    "Name": "traverseType",
+    "Options": {
+        "Tiny Gaps Crossing": "0",
+        "Small Objects Crossing": "1",
+        "Medium Gap Crossing": "3",
+        "Huge Gap Crossing": "7",
+        "Crates Traversal": "2",
+        "Short Fall Down Only": "4",
+        "Medium Fall Down Only": "5",
+        "Window Jump Down": "6",
+        "Short Wall Traversal": "8",
+        "Tall Wall Traversal": "9",
+        "Building Traversal": "10",
+        "Medium Jumps Across Same Level": "11",
+        "Medium Traversal Into Adjacent Levels": "12",
+        "Large Traversal Into Adjacent Levels": "13",
+        "Short Window Traversal": "14",
+        "Long Window Traversal": "15"
+    }
+}

--- a/pilot/r1o/info_hint.json
+++ b/pilot/r1o/info_hint.json
@@ -1,0 +1,65 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_hint",
+    "Description": "https://developer.valvesoftware.com/wiki/Info_Hint",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "StartHintDisabled",
+            "type": "boolean",
+            "name": "Start Hint Disabled",
+            "description": "Spawn the hint disabled"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "Radius",
+            "type": "integer",
+            "name": "Radius",
+            "description": "Allows hints to only be usable in a pre-defined radius"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        },
+        {
+            "keyname": "hotspot",
+            "type": "hintHotspotType",
+            "name": "Hotspot",
+            "description": "Used for some grunt battle chatter lines in Titanfall 1. (ex: 'Checking Window' ... 'Window Clear')"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r1o/info_hint.json
+++ b/pilot/r1o/info_hint.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r1o/info_hint.json
+++ b/pilot/r1o/info_hint.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r1o/prop_exfil_panel.json
+++ b/pilot/r1o/prop_exfil_panel.json
@@ -1,0 +1,17 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "prop_exfil_panel",
+    "Description": "Interactable control panel used by the exfil gamemode",
+    "Keys": [
+        {
+            "keyname": "target",
+            "type": "target",
+            "name": "Target",
+            "description": "Targetname of this panel's target"
+        }
+    ],
+    "Notes": [
+        "Also shares the same keys as prop_dynamic"
+    ]
+}

--- a/pilot/r1o/prop_refuel_pump.json
+++ b/pilot/r1o/prop_refuel_pump.json
@@ -6,7 +6,7 @@
     "Keys": [
         {
             "keyname": "lightingorigin",
-            "type": "string",
+            "type": "target",
             "name": "Lightning Origin",
             "description": "(Optional) Targetname of an entity to use to override the lightling origin"
         }

--- a/pilot/r1o/prop_refuel_pump.json
+++ b/pilot/r1o/prop_refuel_pump.json
@@ -1,0 +1,14 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "prop_refuel_pump",
+    "Description": "Refuel pump used by dropships in Fracture",
+    "Keys": [
+        {
+            "keyname": "lightingorigin",
+            "type": "string",
+            "name": "Lightning Origin",
+            "description": "(Optional) Targetname of an entity to use to override the lightling origin"
+        }
+    ]
+}

--- a/pilot/r1o/prop_weapon_rack.json
+++ b/pilot/r1o/prop_weapon_rack.json
@@ -1,0 +1,17 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "prop_weapon_rack",
+    "Description": "Used by a marvin job type",
+    "Keys": [
+        {
+            "keyname": "racked_weapon",
+            "type": "pilotWeaponType",
+            "name": "Racked Weapon",
+            "description": "Weapon to use"
+        }
+    ],
+    "Notes": [
+        "Probably shares the same keys as prop_dynamic? Its found right next to prop_control_panel on server.dll, which does share them"
+    ]
+}

--- a/pilot/r1o/script_marvin_job.json
+++ b/pilot/r1o/script_marvin_job.json
@@ -1,0 +1,23 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES",
+    "Entity": "script_marvin_job",
+    "Description": "Plays special animations on Marvins",
+    "Keys": [
+        {
+            "keyname": "job",
+            "type": "marvinJobType",
+            "name": "Job",
+            "description": "Job type to use"
+        },
+        {
+            "keyname": "tempJob",
+            "type": "boolean",
+            "name": "Temp Job",
+            "description": "Should this animation only play one time before moving on?"
+        }
+    ],
+    "Notes": [
+        "Probably shares the same keys as prop_dynamic? Its found right next to prop_control_panel on server.dll, which does share them"
+    ]
+}

--- a/pilot/r1o/traverse.json
+++ b/pilot/r1o/traverse.json
@@ -1,0 +1,24 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "traverse",
+    "Description": "Allows special movement actions for NPCs when they get close",
+    "Keys": [
+        {
+            "keyname": "traversetype",
+            "type": "traverseType",
+            "name": "Traverse Type",
+            "description": "Which traverse animation type to use?"
+        },
+        {
+            "keyname": "usableBy",
+            "type": "boolean",
+            "name": "Usable By",
+            "description": "Unknow. Seemingly always 0"
+        }
+    ],
+    "Notes": [
+        "Not all traverse types are supported by all NPC types, since they depend on special animations they may not have",
+		"TODO: somehow find a way to display which types are usable by an NPC class?"
+    ]
+}

--- a/pilot/r2/choiceTypes/hintType.json
+++ b/pilot/r2/choiceTypes/hintType.json
@@ -10,6 +10,6 @@
         "Unknown - Only used by info_node_cover_right": "99",
         "Crouch Cover Medium": "100",
         "Crouch Cover Low": "101",
-        "Unknown": "102"
+        "Waste Scanner Spawn (Likely not accurate anymore)": "102"
     }
 }

--- a/pilot/r2/choiceTypes/hintType.json
+++ b/pilot/r2/choiceTypes/hintType.json
@@ -10,6 +10,6 @@
         "Unknown - Only used by info_node_cover_right": "99",
         "Crouch Cover Medium": "100",
         "Crouch Cover Low": "101",
-        "Waste Scanner Spawn (Likely not accurate anymore)": "102"
+        "Unknown": "102"
     }
 }

--- a/pilot/r2/choiceTypes/hintType.json
+++ b/pilot/r2/choiceTypes/hintType.json
@@ -1,0 +1,15 @@
+{
+    "Name": "hintType",
+    "Options": {
+        "None": "0",
+        "World - Window": "2",
+        "World - Visually Interesting": "13",
+        "World - Visually Interesting (Don't Aim At)": "14",
+        "World - Visually Interesting (Stealth)": "16",
+        "Unknown - Only used by info_node_cover_left": "98",
+        "Unknown - Only used by info_node_cover_right": "99",
+        "Crouch Cover Medium": "100",
+        "Crouch Cover Low": "101",
+        "Waste Scanner Spawn (Likely not accurate anymore)": "102"
+    }
+}

--- a/pilot/r2/choiceTypes/marvinJobType.json
+++ b/pilot/r2/choiceTypes/marvinJobType.json
@@ -1,0 +1,17 @@
+{
+    "Name": "marvinJobType",
+    "Options": {
+        "Fight Fire": "fightFire",
+        "Welding": "welding",
+        "Welding Under": "welding_under",
+        "Wash Window": "window",
+        "Pick Up Barrel": "barrel_pickup",
+        "Put Down Barrel": "barrel_putdown",
+        "Repair Over Edge": "repair_over_edge",
+        "Repair Above": "repair_above",
+        "Repair Under": "repair_under",
+        "Data Cards": "datacards",
+        "Drone Weld": "drone_welding",
+        "Drone Inspect": "drone_inspect"
+    }
+}

--- a/pilot/r2/choiceTypes/marvinJobType.json
+++ b/pilot/r2/choiceTypes/marvinJobType.json
@@ -11,7 +11,7 @@
         "Repair Above": "repair_above",
         "Repair Under": "repair_under",
         "Data Cards": "datacards",
-        "Drone Weld": "drone_welding",
+        "Drone Welding": "drone_welding",
         "Drone Inspect": "drone_inspect"
     }
 }

--- a/pilot/r2/choiceTypes/traverseType.json
+++ b/pilot/r2/choiceTypes/traverseType.json
@@ -1,0 +1,26 @@
+{
+    "Name": "traverseType",
+    "Options": {
+        "Tiny Gaps Crossing": "0",
+        "Small Objects Crossing": "1",
+        "Medium Gap Crossing": "3",
+        "Huge Gap Crossing": "7",
+        "Crates Traversal": "2",
+        "Short Fall Down Only": "4",
+        "Medium Fall Down Only": "5",
+        "Window Jump Down": "6",
+        "Short Wall Traversal": "8",
+        "Tall Wall Traversal": "9",
+        "Building Traversal": "10",
+        "Tall Wall Traversal (Climb)": "19",
+        "Building Traversal (Climb)": "20",
+        "Short Jumps Across Same Level": "16",
+        "Medium Jumps Across Same Level": "11",
+        "Medium Traversal Into Adjacent Levels": "12",
+        "Large Traversal Into Adjacent Levels": "13",
+        "Short Window Traversal": "14",
+        "Long Window Traversal": "15",
+        "Diagonal Medium Traversal": "17",
+        "Door Traversal": "18"
+    }
+}

--- a/pilot/r2/info_hint.json
+++ b/pilot/r2/info_hint.json
@@ -1,0 +1,59 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_hint",
+    "Description": "https://developer.valvesoftware.com/wiki/Info_Hint",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "StartHintDisabled",
+            "type": "boolean",
+            "name": "Start Hint Disabled",
+            "description": "Spawn the hint disabled"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "Radius",
+            "type": "integer",
+            "name": "Radius",
+            "description": "Allows hints to only be usable in a pre-defined radius"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r2/info_hint.json
+++ b/pilot/r2/info_hint.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_hint.json
+++ b/pilot/r2/info_hint.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node.json
+++ b/pilot/r2/info_node.json
@@ -1,0 +1,9 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node",
+    "Description": "https://developer.valvesoftware.com/wiki/Info_node",
+    "Notes": [
+        "Spectre info_nodes use the unknown spawnflag 1048576"
+    ]
+}

--- a/pilot/r2/info_node_air.json
+++ b/pilot/r2/info_node_air.json
@@ -1,0 +1,6 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node_air",
+    "Description": "https://developer.valvesoftware.com/wiki/Info_node_air"
+}

--- a/pilot/r2/info_node_cover_crouch.json
+++ b/pilot/r2/info_node_cover_crouch.json
@@ -1,0 +1,53 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node_cover_crouch",
+    "Description": "Tells an NPC that there's cover here",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "StartHintDisabled",
+            "type": "boolean",
+            "name": "Start Hint Disabled",
+            "description": "Spawn the hint disabled"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r2/info_node_cover_crouch.json
+++ b/pilot/r2/info_node_cover_crouch.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_crouch.json
+++ b/pilot/r2/info_node_cover_crouch.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_left.json
+++ b/pilot/r2/info_node_cover_left.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_left.json
+++ b/pilot/r2/info_node_cover_left.json
@@ -1,0 +1,53 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node_cover_left",
+    "Description": "Tells an NPC that there's cover here",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "StartHintDisabled",
+            "type": "boolean",
+            "name": "Start Hint Disabled",
+            "description": "Spawn the hint disabled"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r2/info_node_cover_left.json
+++ b/pilot/r2/info_node_cover_left.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_right.json
+++ b/pilot/r2/info_node_cover_right.json
@@ -1,0 +1,53 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node_cover_right",
+    "Description": "Tells an NPC that there's cover here",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "StartHintDisabled",
+            "type": "boolean",
+            "name": "Start Hint Disabled",
+            "description": "Spawn the hint disabled"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r2/info_node_cover_right.json
+++ b/pilot/r2/info_node_cover_right.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_right.json
+++ b/pilot/r2/info_node_cover_right.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_stand.json
+++ b/pilot/r2/info_node_cover_stand.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_cover_stand.json
+++ b/pilot/r2/info_node_cover_stand.json
@@ -1,0 +1,53 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node_cover_stand",
+    "Description": "Tells an NPC that there's cover here",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "StartHintDisabled",
+            "type": "boolean",
+            "name": "Start Hint Disabled",
+            "description": "Spawn the hint disabled"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r2/info_node_cover_stand.json
+++ b/pilot/r2/info_node_cover_stand.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_safe_hint.json
+++ b/pilot/r2/info_node_safe_hint.json
@@ -1,0 +1,47 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "info_node_safe_hint",
+    "Description": "Tells an NPC that there's cover here",
+    "Keys": [
+        {
+            "keyname": "hinttype",
+            "type": "hintType",
+            "name": "Hint Type",
+            "description": ""
+        },
+        {
+            "keyname": "nodeFOV",
+            "type": "integer",
+            "name": "Node FOV",
+            "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
+        },
+        {
+            "keyname": "TargetNode",
+            "type": "integer",
+            "name": "Target Node",
+            "description": "The node ID of an associated target node, if any"
+        },
+        {
+            "keyname": "IgnoreFacing",
+            "type": "boolean",
+            "name": "Ignore Facing",
+            "description": "Don't pay attention to the facing of the node. May not apply to a given hint type"
+        },
+        {
+            "keyname": "MinimumState",
+            "type": "integer",
+            "name": "Minimum State",
+            "description": "Require an NPC have a minimum state to use the hint. Seemingly always 1 in Titanfall"
+        },
+        {
+            "keyname": "MaximumState",
+            "type": "integer",
+            "name": "Maximum State",
+            "description": "Require an NPC have a maximum state to use the hint. Seemingly always 3 in Titanfall"
+        }
+    ],
+    "Notes": [
+		"nodeFOV should be in between 0 - 360"
+    ]
+}

--- a/pilot/r2/info_node_safe_hint.json
+++ b/pilot/r2/info_node_safe_hint.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "float",
+            "type": "integer",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/info_node_safe_hint.json
+++ b/pilot/r2/info_node_safe_hint.json
@@ -12,7 +12,7 @@
         },
         {
             "keyname": "nodeFOV",
-            "type": "integer",
+            "type": "float",
             "name": "Node FOV",
             "description": "Imagine this node requires that an NPC be in the node's field of view in order to use this hint"
         },

--- a/pilot/r2/prop_control_panel.json
+++ b/pilot/r2/prop_control_panel.json
@@ -1,0 +1,17 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "prop_control_panel",
+    "Description": "Interactable control panel",
+    "Keys": [
+        {
+            "keyname": "target",
+            "type": "target",
+            "name": "Target",
+            "description": "Targetname of an npc_turrret_mega linked to this panel"
+        }
+    ],
+    "Notes": [
+        "Also shares the same keys as prop_dynamic"
+    ]
+}

--- a/pilot/r2/script_marvin_job.json
+++ b/pilot/r2/script_marvin_job.json
@@ -1,0 +1,30 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "script_marvin_job",
+    "Description": "Plays special animations on Marvins",
+    "Keys": [
+        {
+            "keyname": "job",
+            "type": "marvinJobType",
+            "name": "Job",
+            "description": "Job type to use"
+        },
+        {
+            "keyname": "tempJob",
+            "type": "boolean",
+            "name": "Temp Job",
+            "description": "Should this animation only play one time before moving on?"
+        },
+        {
+            "keyname": "hover",
+            "type": "boolean",
+            "name": "Hover",
+            "description": "Drop this entity to the ground on map load"
+        }
+    ],
+    "Notes": [
+        "Probably shares the same keys as prop_dynamic? Its found right next to prop_control_panel on server.dll, which does share them",
+		"Hover should only be turned on for Drone jobs"
+    ]
+}

--- a/pilot/r2/traverse.json
+++ b/pilot/r2/traverse.json
@@ -1,0 +1,24 @@
+{
+    "Contributors": ["NachosChipeados"],
+    "Block": "ENTITIES_script",
+    "Entity": "traverse",
+    "Description": "Allows special movement actions for NPCs when they get close",
+    "Keys": [
+        {
+            "keyname": "traversetype",
+            "type": "traverseType",
+            "name": "Traverse Type",
+            "description": "Which traverse animation type to use?"
+        },
+        {
+            "keyname": "usableBy",
+            "type": "boolean",
+            "name": "Usable By",
+            "description": "Unknow. Seemingly always 0"
+        }
+    ],
+    "Notes": [
+        "Not all traverse types are supported by all NPC types",
+		"TODO: somehow find a way to display which types are usable by an NPC class?"
+    ]
+}


### PR DESCRIPTION
Adds more script entities. The traverseType list was taken from this message on the northstar discord: https://discord.com/channels/920776187884732556/925135799798874192/1286307238927011963

<img width="817" height="408" alt="image" src="https://github.com/user-attachments/assets/b8a5e986-cc25-4fe7-8068-6f98d6bed3ad" />